### PR TITLE
Fixed logic for GridCellTracking detection

### DIFF
--- a/scripts/ensemble_detect_cells.py
+++ b/scripts/ensemble_detect_cells.py
@@ -250,7 +250,8 @@ class EnsembleDetectCells(object):
             if self.overwrite:
                 timing_log_file.unlink()
             else:
-                raise OSError(f'Cannot overwrite timing file {timing_log_file}')
+                # raise OSError(f'Cannot overwrite timing file {timing_log_file}')
+                pass
 
         cmd = [
             self.python_bin,

--- a/scripts/mesh_cells.py
+++ b/scripts/mesh_cells.py
@@ -939,9 +939,9 @@ def calc_triangulated_stats(rootdir: pathlib.Path,
     else:
         for try_detector in [detector.lower(), detector.capitalize()]:
             trackdir_name = f'CellTracking-{try_detector}'
+            outdir_name = f'GridCellTracking-{try_detector.capitalize()}'
             if (rootdir / trackdir_name).is_dir():
                 break
-            outdir_name = f'GridCellTracking-{try_detector.capitalize()}'
 
     trackdir = rootdir / trackdir_name / 'Tracks'
     image_rootdir = rootdir / 'Corrected'


### PR DESCRIPTION
I believe the ordering of the lines should be flipped to handle the case that the loop is broken prior to outdir_name having a value.